### PR TITLE
Fix: Support cuda-python >=13 by updating cudart import path

### DIFF
--- a/trt_utilities.py
+++ b/trt_utilities.py
@@ -16,7 +16,24 @@ import tensorrt as trt
 from logging import error, warning
 from tqdm import tqdm
 import copy
-from cuda import cudart
+
+# Support cuda-python <=12.x (cuda.cudart) and >=13.x (cuda.bindings.runtime)
+try:
+    # CUDA Python <= 12.x layout
+    from cuda import cudart as cudart  # type: ignore
+    _CUDART_SRC = "cuda.cudart"
+except Exception:  # pragma: no cover
+    # CUDA Python >= 13.x metapackage layout
+    from cuda.bindings import runtime as cudart  # type: ignore
+    _CUDART_SRC = "cuda.bindings.runtime"
+
+# Optional: tiny debug line; comment out if you don't want import-time logs
+try:
+    from importlib.metadata import version as _pkg_version
+    _cuda_py_ver = _pkg_version("cuda-python")
+except Exception:  # pragma: no cover
+    _cuda_py_ver = "unknown"
+# print(f"[ComfyUI-Rife-TensorRT] Using {_CUDART_SRC} (cuda-python={_cuda_py_ver})")
 
 TRT_LOGGER = trt.Logger(trt.Logger.ERROR)
 G_LOGGER.module_severity = G_LOGGER.ERROR


### PR DESCRIPTION
This PR updates the import path for `cudart` to support both cuda-python <=12.x and >=13.x.

In cuda-python 13, the `cudart` module was moved from `cuda.cudart` to `cuda.bindings.runtime`.
      This change implements a backward-compatible dual-path import that works with both versions.

Changes:
- Modified `trt_utilities.py` to use try/except import pattern
- First attempts to import from `cuda.cudart` (for <=12.x)- Falls back to
      `cuda.bindings.runtime` (for >=13.x)- Added version tracking for debugging purposes (commented
      out by default)
  
    This change ensures compatibility with newer versions of cuda-python while maintaining support
      for existing installations.k