### PR TITLE
fix: add export_trt.py to sys.path to fix it for use with comfyui's python_embeded/python.exe

### DIFF
--- a/export_trt.py
+++ b/export_trt.py
@@ -1,3 +1,6 @@
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 import torch
 import time
 from trt_utilities import Engine


### PR DESCRIPTION
`..\..\..\..\python_embeded\python.exe .\export_trt.py`

Repeatedly had "ModuleNotFoundError: No module named 'trt_utilities'" without it.